### PR TITLE
request-params adding request params to request resolver response

### DIFF
--- a/src/web/Request.php
+++ b/src/web/Request.php
@@ -94,7 +94,7 @@ class Request extends \yii\web\Request
         $result = Yii::$app->getUrlManager()->parseRequest($this);
         if ($result !== false) {
             list($route, $params) = $result;
-            return [$route, $this->getQueryParams()];
+            return [$route, $params + $this->getQueryParams()];
         }
 
         throw new NotFoundHttpException(Yii::t('yii', 'Page not found.'));


### PR DESCRIPTION
PR resolves problem with actions as components, when method run has arguments.

Example:
public function run($param)

Without this fix the param doesn't come.