### PR TITLE
Aligns yii\Psr7\Request::getQueryParams() to yii\web\Request::getQueryParams()

### DIFF
--- a/src/web/Request.php
+++ b/src/web/Request.php
@@ -95,7 +95,11 @@ class Request extends \yii\web\Request
         $result = Yii::$app->getUrlManager()->parseRequest($this);
         if ($result !== false) {
             list($route, $params) = $result;
-            return [$route, $params + $this->getQueryParams()];
+            if ($this->_queryParams === null) {
+                $this->_queryParams = $params + $this->getPsr7Request()->getQueryParams();
+            }
+
+            return [$route, $this->_queryParams];
         }
 
         throw new NotFoundHttpException(Yii::t('yii', 'Page not found.'));
@@ -201,7 +205,7 @@ class Request extends \yii\web\Request
      */
     public function getQueryParams()
     {
-        return $this->getPsr7Request()->getQueryParams();
+        return $this->_queryParams;
     }
 
     /**
@@ -480,3 +484,4 @@ class Request extends \yii\web\Request
         return $this->_hostInfo;
     }
 }
+

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -247,4 +247,21 @@ class ApplicationTest extends AbstractTestCase
         $this->assertInstanceOf('\Psr\Http\Message\ResponseInterface', $response);
         $this->assertEquals(500, $response->getStatusCode());
     }
+
+    public function testQueryParametersAlignWithYiiWebRequestInstance()
+    {
+        $request = ServerRequestFactory::fromGlobals([
+            'REQUEST_URI' => 'site/query/foo?q=1',
+            'REQUEST_METHOD' => 'GET'
+        ], [
+            'q' => 1
+        ]);
+
+        $response = $this->app->handle($request);
+        $this->assertInstanceOf('\Psr\Http\Message\ResponseInterface', $response);
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $body = $response->getBody()->getContents();
+        $this->assertEquals('{"test":"foo","q":1,"queryParams":{"test":"foo","q":1}}', $body);
+    }
 }

--- a/tests/config/config.php
+++ b/tests/config/config.php
@@ -50,9 +50,9 @@ return [
             'enablePrettyUrl'       => true,
             'rules' => [
                 [
-                    'pattern'   => '/<controller>/<action>',
+                    'pattern'   => '/<controller>/<action>/<test:\w+>',
                     'route'     => '<controller>/<action>'
-                ]
+                ],
             ]
         ]
     ],

--- a/tests/controllers/SiteController.php
+++ b/tests/controllers/SiteController.php
@@ -100,4 +100,14 @@ class SiteController extends Controller
     {
         throw new \Exception("General Exception");
     }
+
+    public function actionQuery($test) {
+        $response = Yii::$app->response;
+        $response->format = Response::FORMAT_JSON;
+        return [
+            'test' => $test,
+            'q' => Yii::$app->request->get('q'),
+            'queryParams' => Yii::$app->request->getQueryParams()
+        ];
+    }
 }


### PR DESCRIPTION
PSR7 Query parameters don't include URI Path Arguments, but Yii2 translations do in yii\Psr7\Request::resolve()

This should be considered "by-design" with PSR7 objects, however it is
being resolved for compatibility with Yii2's update Request object.

Fixes #9