### PR TITLE
Deregister any existing error handler since `ErrorHandler::register()` allocates memory on each request

### DIFF
--- a/src/web/Application.php
+++ b/src/web/Application.php
@@ -44,6 +44,11 @@ class Application extends \yii\web\Application implements RequestHandlerInterfac
     private $monitors = [];
 
     /**
+     * @var bool Is this the first `reset()` call
+     */
+    private $firstReset = true;
+
+    /**
      * Overloaded constructor to persist configuration
      *
      * @param array $config
@@ -102,9 +107,12 @@ class Application extends \yii\web\Application implements RequestHandlerInterfac
         $this->state = self::STATE_BEGIN;
         $this->preInit($config);
 
-        // Deregister any existing error handler since std_pad allocates 256K on each request
-        if ($errorHandler = $this->getErrorHandler() !== null) {
-            $errorHandler->unregister();
+        // Deregister any existing error handler since `ErrorHandler::register()` allocates memory on each request
+        if ($this->firstReset) {
+            // Accessing `$this->errorHandler` on the first run would throw an error; skip it
+            $this->firstReset = false;
+        } elseif ($this->errorHandler !== null) {
+            $this->errorHandler->unregister();
         }
 
         $this->registerErrorHandler($config);


### PR DESCRIPTION
Fixes #14

The deb2044 exact code won’t work on the first run/iteration (accessing `$this->getErrorHandler()` would throw an error), so we need some additional flag.

This significally reduces memory leaks, described in #14 and https://github.com/yiisoft/yii2/issues/19738.

Before (1000 iterations, overall memory usage per worker is about 600 MB):

![image](https://user-images.githubusercontent.com/980679/212647068-37b520e6-8adc-47a4-9d73-e3d004f5876c.png)

After (1000 iterations, overall memory usage per worker is about 100 MB):

![image](https://user-images.githubusercontent.com/980679/212641565-153ed349-d128-48d3-bf4f-fb4954297714.png)
